### PR TITLE
fix: noticket - Don't spin so hard, pls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN  python3 -m ensurepip && \
      pip3 --no-cache-dir install --upgrade pip setuptools && \
      pip3 --no-cache-dir install ".[server]"
 
+RUN sed -i 's/0[.]001/0.01/' /usr/lib/python3.6/site-packages/moto/sqs/models.py
+
 ENTRYPOINT ["/usr/bin/moto_server", "-H", "0.0.0.0"]
 
 EXPOSE 5000


### PR DESCRIPTION
Based on David's investigation in #vm-to-docker

> david [15:16]
> work-around until I can make a branch that uses proper synchronisation primitives (I might want a hand with that, if anyone wants to pair):
> * `docker-compose exec motoserver cat /usr/lib/python3.6/site-packages/moto/sqs/models.py | sed 's/0[.]001/0.1/' > ./deploy/dockers/moto/models.py`
> * `echo deploy/dockers/moto/models.py >> .git/info/exclude`
> * add this to docker-compose.override.yml:
>    ```motoserver:
>     volumes:
>     - ./deploy/dockers/moto/models.py:/usr/lib/python3.6/site-packages/moto/sqs/models.py```
> * `docker-compose up -d` to apply the changes
> 
> solr/gunicorn/mongo then become the top cpu abusers, according to `docker run --rm -it --pid host frapsoft/htop`